### PR TITLE
Add support for Companion app; QuestPDF 2024.10.3+

### DIFF
--- a/src/QuestPdf.Barcodes/QuestPdf.Barcodes.csproj
+++ b/src/QuestPdf.Barcodes/QuestPdf.Barcodes.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Barcoder" Version="[2.0.0,)" />
-    <PackageReference Include="QuestPDF" Version="[2024.3.6,)" />
+    <PackageReference Include="QuestPDF" Version="[2024.10.3,)" />
     <PackageReference Include="SvgLib" Version="[1.0.0.3,)" />
   </ItemGroup>
 

--- a/src/QuestPdf.Playground/Program.cs
+++ b/src/QuestPdf.Playground/Program.cs
@@ -1,8 +1,8 @@
+using QuestPDF.Companion;
 using QuestPDF.Drawing;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
-using QuestPDF.Previewer;
 using SixLabors.Fonts;
 
 namespace QuestPdf.Playground
@@ -51,7 +51,7 @@ namespace QuestPdf.Playground
       //document.GeneratePdf("hello.pdf");
 
       // use the following invocation
-      document.ShowInPreviewer(12500);
+      document.ShowInCompanion();
     }
 
     private static void TestFontSize()


### PR DESCRIPTION
Using QuestPDF.Barcodes in a project that also uses QuestPDF works great until QuestPDF is updated to 2024.12 or greater. Upgrading QuestPDF in the project fixes the problem.